### PR TITLE
Update leaflet-rotate.spec.js with setView check on bering change

### DIFF
--- a/examples/leaflet-rotate.spec.js
+++ b/examples/leaflet-rotate.spec.js
@@ -33,6 +33,20 @@ test('set bearing and zoom in/out', async ({ page }) => {
   assert.is(bearing_2, 10);
 });
 
+// assertion fails for second setView
+test('set bearing and set view', async ({ page }) => {
+  const { bearing_0, bearing_1, bearing_2 } = await page.evaluate(() => new Promise(resolve => {
+    let bearing_0, bearing_1, bearing_2;
+    map.setBearing(10); bearing_0 = map.getBearing();
+    map.setView({ lat: 50.5, lng: 30.5 }, 15, {});       bearing_1 = map.getBearing();
+    map.setView({ lat: 51.5, lng: 34.5 }, 17, {});       bearing_1 = map.getBearing();
+    resolve({ bearing_0, bearing_1, bearing_2 });
+  }));
+  assert.is(bearing_0, 10);
+  assert.is(bearing_1, 10);
+  // assert.is(bearing_2, 10);
+});
+
 /**
  * @see https://github.com/Raruto/leaflet-rotate/issues/25
  */

--- a/examples/leaflet-rotate.spec.js
+++ b/examples/leaflet-rotate.spec.js
@@ -39,7 +39,7 @@ test('set bearing and set view', async ({ page }) => {
     let bearing_0, bearing_1, bearing_2;
     map.setBearing(10); bearing_0 = map.getBearing();
     map.setView({ lat: 50.5, lng: 30.5 }, 15, {});       bearing_1 = map.getBearing();
-    map.setView({ lat: 51.5, lng: 34.5 }, 17, {});       bearing_1 = map.getBearing();
+    map.setView({ lat: 51.5, lng: 34.5 }, 17, {});       bearing_2 = map.getBearing();
     resolve({ bearing_0, bearing_1, bearing_2 });
   }));
   assert.is(bearing_0, 10);

--- a/examples/leaflet-rotate.spec.js
+++ b/examples/leaflet-rotate.spec.js
@@ -44,7 +44,7 @@ test('set bearing and set view', async ({ page }) => {
   }));
   assert.is(bearing_0, 10);
   assert.is(bearing_1, 10);
-  // assert.is(bearing_2, 10);
+  assert.is(bearing_2, 10);
 });
 
 /**


### PR DESCRIPTION
Like in the script comments, the second setView fails. Not sure if this is expected. Below is the log.

```
FAIL  examples/leaflet-rotate.html  "set bearing and set view"
Expected values to be strictly equal:  (is)

        ++10         [number]     (Expected)
--undefined  [undefined]  (Actual)

        at assert (file:///run/media/user/96242da8-b37a-4597-9b64-uuidstr/repos/leaflet-rotate/node_modules/uvu/assert/index.mjs:33:8)
        at Module.is (file:///run/media/user/96242da8-b37a-4597-9b64-uuidstr/repos/leaflet-rotate/node_modules/uvu/assert/index.mjs:41:2)
        at file:///run/media/user/96242da8-b37a-4597-9b64-uuidstr/repos/leaflet-rotate/examples/leaflet-rotate.spec.js:33:10
        at async Number.runner (file:///run/media/user/96242da8-b37a-4597-9b64-uuidstr/repos/leaflet-rotate/node_modules/uvu/dist/index.mjs:78:5)
        at async Module.exec (file:///run/media/user/96242da8-b37a-4597-9b64-uuidstr/repos/leaflet-rotate/node_modules/uvu/dist/index.mjs:141:33)
        at async Module.run (file:///run/media/user/96242da8-b37a-4597-9b64-uuidstr/repos/leaflet-rotate/node_modules/uvu/run/index.mjs:12:2)
        at async /run/media/user/96242da8-b37a-4597-9b64-uuidstr/repos/leaflet-rotate/node_modules/uvu/bin.js:26:5

``` 

Also, I was unable to `import L from "leaflet"` . I got `ReferenceError: window is not defined` and none of the tests ran.